### PR TITLE
Fixes #19

### DIFF
--- a/include/restc-cpp/restc-cpp.h
+++ b/include/restc-cpp/restc-cpp.h
@@ -23,7 +23,7 @@
 #include "restc-cpp/helper.h"
 #include "restc-cpp/Connection.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 // Thank you Microsoft for making every developers day productive
 #ifdef min
 #   undef min


### PR DESCRIPTION
Checks for mingw32 alongside msvc, allowing the library to compile on MSYS2/MinGW.