### PR TITLE
possible resource leak if virtual dtor called on base

### DIFF
--- a/include/restc-cpp/restc-cpp.h
+++ b/include/restc-cpp/restc-cpp.h
@@ -267,6 +267,7 @@ public:
  */
 class Context {
 public:
+    virtual ~Context() {}
     virtual boost::asio::yield_context& GetYield() = 0;
     virtual RestClient& GetClient() = 0;
 


### PR DESCRIPTION
fix error: if this is a base class and dtor is called on ptr to base then the derrived dtor will not be called

../../restc-cpp/include/restc-cpp/restc-cpp.h:268:7: error: ‘class restc_cpp::Context’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
 class Context {