### PR TITLE
Improve build for package managers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ if (RESTC_CPP_FETCH_DEPENDENCIES)
 else()
     find_package(RapidJSON 1.1 REQUIRED)
 endif()
+include(CMakePrintHelpers)
+cmake_print_variables(RAPIDJSON_INCLUDE_DIRS)
 
 if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     message(STATUS "Using conan configuration: ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
@@ -144,6 +146,14 @@ target_include_directories(${PROJECT_NAME}
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/generated-include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
+
+# As our public headers expose RapidJSON, RapidJSON should be part of the public interface.
+# Nevertheless we can't put the locally fetched version into the public interface.
+if(RESTC_CPP_FETCH_DEPENDENCIES)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
+else()
+    target_include_directories(${PROJECT_NAME} PUBLIC  ${RAPIDJSON_INCLUDE_DIRS})
+endif()
 
 SET_CPP_STANDARD(${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,20 @@ if (NOT DEFINED INSTALL_RAPIDJSON_HEADERS)
     option(INSTALL_RAPIDJSON_HEADERS "Install rapidjson headers when make install is executed" ON)
 endif()
 
-include(cmake_scripts/external-projects.cmake)
+if (NOT DEFINED RESTC_CPP_FETCH_DEPENDENCIES)
+    option(RESTC_CPP_FETCH_DEPENDENCIES "Use the ExternalProject fetcher to fetch dependencies like rapidjson and lest." ON)
+endif()
+
+include(CMakeDependentOption)
+
+cmake_dependent_option(INSTALL_RAPIDJSON_HEADERS "Install rapidjson headers when make install is executed" ON
+    "RESTC_CPP_FETCH_DEPENDENCIES" OFF)
+
+if (RESTC_CPP_FETCH_DEPENDENCIES)
+    include(cmake_scripts/external-projects.cmake)
+else()
+    find_package(RapidJSON 1.1 REQUIRED)
+endif()
 
 if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     message(STATUS "Using conan configuration: ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
@@ -134,7 +147,9 @@ target_include_directories(${PROJECT_NAME}
 
 SET_CPP_STANDARD(${PROJECT_NAME})
 
-add_dependencies(${PROJECT_NAME} externalRapidJson)
+if (NOT DEFINED RESTC_CPP_FETCH_DEPENDENCIES)
+    add_dependencies(${PROJECT_NAME} externalRapidJson)
+endif()
 
 if (NOT EMBEDDED_RESTC_CPP)
 

--- a/cmake_scripts/external-projects.cmake
+++ b/cmake_scripts/external-projects.cmake
@@ -21,7 +21,7 @@ ExternalProject_Add(
     LOG_INSTALL ON
     )
 
-set(EXTERNAL_RAPIDJSON_INCLUDE_DIR ${EXTERNAL_PROJECTS_PREFIX}/src/externalRapidJson/include/rapidjson)
+set(RAPIDJSON_INCLUDE_DIRS ${EXTERNAL_PROJECTS_PREFIX}/src/externalRapidJson/include/rapidjson)
 
 ExternalProject_Add(
     externalLest
@@ -35,13 +35,10 @@ ExternalProject_Add(
     LOG_INSTALL ON
     )
 
-message(STATUS "EXTERNAL_RAPIDJSON_INCLUDE_DIR: ${EXTERNAL_RAPIDJSON_INCLUDE_DIR}")
-
 if (INSTALL_RAPIDJSON_HEADERS)
-    install(DIRECTORY ${EXTERNAL_RAPIDJSON_INCLUDE_DIR} DESTINATION include)
+    install(DIRECTORY ${RAPIDJSON_INCLUDE_DIRS} DESTINATION include)
 endif()
 
 include_directories(
-     ${EXTERNAL_PROJECTS_PREFIX}/src/externalRapidJson/include
      ${EXTERNAL_PROJECTS_PREFIX}/src/externalLest/include/
-    )
+)


### PR DESCRIPTION
CMake's ExternalProject fetcher is handy but only useful when no
other facility provides dependencies. If we want to use
vcpkg, Yocto or similar facilities which can provide dependencies as
 packages, we need to turn off CMake's fetcher.

Vcpkg, conan, Yocto and others would really help to use this nice library and would make it well-known.

This change introduces a new option to turn off the fetching of RapidJSON and Lest while keeping the build options and behaviour backwards compatible.
