### PR TITLE
fix missing port in proxy mode

### DIFF
--- a/src/RequestImpl.cpp
+++ b/src/RequestImpl.cpp
@@ -478,7 +478,7 @@ private:
         request_buffer << Verb(request_type_) << ' ';
 
         if (properties_->proxy.type == Request::Proxy::Type::HTTP) {
-            request_buffer << parsed_url_.GetProtocolName() << parsed_url_.GetHost();
+            request_buffer << parsed_url_.GetProtocolName() << parsed_url_.GetHost() << ":" << parsed_url_.GetPort();
         }
 
         // Add arguments to the path as ?name=value&name=value...


### PR DESCRIPTION
Whenever trying to use a proxy with URLs such like "http://196.168.1.1:8080/my/path" the port number "8080" gets cut off (validated by mitmproxy). In https://github.com/jgaa/restc-cpp/issues/87 @JackieKu already proposed a solution which I just integrated into the current master branch. The question is, if the port number shall be omitted, whenever it is a standard port 80 for http or 443 for https?